### PR TITLE
Fix Twig 3 syntax error in menu--inline-unit template

### DIFF
--- a/templates/menu/menu--inline-unit.html.twig
+++ b/templates/menu/menu--inline-unit.html.twig
@@ -21,20 +21,22 @@
 #}
 
 <ul class="menu menu-level-{{ items|first.menu_level }}">
-  {% for key, item in items if key|first != '#' %}
-    {% set menu_item_classes = [
-      'menu-item',
-      item.is_expanded ? 'menu-item--expanded',
-      item.is_collapsed ? 'menu-item--collapsed',
-      item.in_active_trail ? 'menu-item--active-trail',
-    ] %}
-    <li{{ item.attributes.addClass(menu_item_classes) }}>
-      {{ link(item.title, item.url) }}
+  {% for key, item in items %}
+    {% if key|first != '#' %}
+      {% set menu_item_classes = [
+        'menu-item',
+        item.is_expanded ? 'menu-item--expanded',
+        item.is_collapsed ? 'menu-item--collapsed',
+        item.in_active_trail ? 'menu-item--active-trail',
+      ] %}
+      <li{{ item.attributes.addClass(menu_item_classes) }}>
+        {{ link(item.title, item.url) }}
 
-      {% set rendered_content = item.content|without('') %}
-      {% if rendered_content|render %}
-        {{ rendered_content }}
-      {% endif %}
-    </li>
+        {% set rendered_content = item.content|without('') %}
+        {% if rendered_content|render %}
+          {{ rendered_content }}
+        {% endif %}
+      </li>
+    {% endif %}
   {% endfor %}
 </ul>


### PR DESCRIPTION
Move inline if condition from for loop declaration to inside the loop body for Twig 3 compatibility. The syntax  is not supported in Twig 3 and causes a parse error. Refactored to use standard for loop with if condition inside.

Fixes #29