### PR TITLE
Re-add h3,h4 styling from D9 theme

### DIFF
--- a/scss/_du-customizations-only.scss
+++ b/scss/_du-customizations-only.scss
@@ -233,6 +233,20 @@ h2,
   margin-top: 0;
   margin-bottom: 0.9rem; }
 
+h3, .h3 {
+  font-size: 2.8rem;
+  line-height: 1.2;
+  margin-top: 0;
+  margin-bottom: 0.9rem;
+}
+
+h4, .h4 {
+  font-size: 2.6rem;
+  line-height: 1.2;
+  margin-top: 0;
+  margin-bottom: 0.9rem;
+}
+
 h5, .h5 {
   font-size: 2.1rem;
   line-height: 1.2;


### PR DESCRIPTION
Not sure how to test this across sites, but it does fit the pattern in the SCSS file where headings were located.