### PR TITLE
sub theme updates needed for Drupal 11 compatibility

### DIFF
--- a/js/jquery-type-compat.js
+++ b/js/jquery-type-compat.js
@@ -1,0 +1,20 @@
+/**
+ * @file
+ * Restores the jQuery.type() API required by Slick 1.8.1 under jQuery 4.
+ */
+
+(function ($) {
+  'use strict';
+
+  if (typeof $.type !== 'function') {
+    $.type = function (value) {
+      if (value === null || value === undefined) {
+        return String(value);
+      }
+
+      return typeof value === 'object' || typeof value === 'function'
+        ? Object.prototype.toString.call(value).slice(8, -1).toLowerCase()
+        : typeof value;
+    };
+  }
+})(jQuery);

--- a/pl_drupal.libraries.yml
+++ b/pl_drupal.libraries.yml
@@ -31,6 +31,8 @@ core:
     dest/libraries/jquery.scrollto/jquery.scrollTo.min.js:
       minified: true
       preprocess: false
+    js/jquery-type-compat.js:
+      preprocess: false
     dest/libraries/slick-carousel/slick/slick.min.js:
       minified: true
       preprocess: true

--- a/subthemes/pl_micro/pl_micro.info.yml
+++ b/subthemes/pl_micro/pl_micro.info.yml
@@ -3,7 +3,7 @@ type: theme
 description: Micro site theme with Pattern Lab
 base theme: pl_drupal
 version: 3.0.0-beta4
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^10 || ^11
 libraries: {}
 regions:
   #header: Header

--- a/subthemes/pl_micro/pl_micro.info.yml
+++ b/subthemes/pl_micro/pl_micro.info.yml
@@ -4,7 +4,6 @@ description: Micro site theme with Pattern Lab
 base theme: pl_drupal
 version: 3.0.0-beta4
 core_version_requirement: ^10 || ^11
-libraries: {}
 regions:
   #header: Header
   utility_nav: Utility Nav

--- a/subthemes/pl_micro/pl_micro.libraries.yml
+++ b/subthemes/pl_micro/pl_micro.libraries.yml
@@ -1,24 +1,5 @@
+# Preserve the legacy subtheme library handle while using base theme assets.
 core:
   version: 1.x
-  css:
-    theme:
-      /core/themes/seven/css/components/tabs.css:
-        preprocess: false
-      bower_components/motion-ui/dist/motion-ui.min.css:
-        preprocess: true
-      dest/style.css:
-        preprocess: false
-  js:
-    dest/script.js:
-      preprocess: true
-    bower_components/foundation-sites/dist/js/foundation.min.js:
-      preprocess: true
-    js/app.js:
-      preprocess: true
-
-  # see all in Drupal's `core/core.libraries.yml`
   dependencies:
-    - core/jquery
-    - core/drupal
-    - core/jquery.cookie
-    - core/jquery.once
+    - pl_drupal/core

--- a/subthemes/pl_micro/pl_micro.theme
+++ b/subthemes/pl_micro/pl_micro.theme
@@ -70,7 +70,7 @@ function pl_micro_preprocess_page(&$variables) {
       if ($hero_paragraph->getType() == 'experiential_story') {
         $view_builder = \Drupal::entityTypeManager()->getViewBuilder('paragraph');
         $build = $view_builder->view($hero_paragraph, 'full');
-        $variables['experiential_story'] = render($build);
+        $variables['experiential_story'] = $build;
       }
       else {
         if (!empty($hero_paragraph->get('field_hero_image')->entity)) {
@@ -146,7 +146,7 @@ function pl_micro_preprocess_page(&$variables) {
                       }
                       if (!empty($hero_paragraph->get('field_hero_video')->entity)) {
                         $video = $hero_paragraph->get('field_hero_video')->entity;
-                        $variables['hero_video_url'] = file_create_url($video->get('uri')
+                        $variables['hero_video_url'] = \Drupal::service('file_url_generator')->generateAbsoluteString($video->get('uri')
                           ->getString());
                       }
                       if ($hero_paragraph->hasField('field_unit_hero_link')) {

--- a/subthemes/pl_unit/pl_unit.info.yml
+++ b/subthemes/pl_unit/pl_unit.info.yml
@@ -4,7 +4,6 @@ description: Unit theme with Pattern Lab
 base theme: pl_drupal
 version: 3.0.0-beta4
 core_version_requirement: ^10 || ^11
-libraries: {}
 regions:
   #header: Header
   utility_nav: Utility Nav

--- a/subthemes/pl_unit/pl_unit.info.yml
+++ b/subthemes/pl_unit/pl_unit.info.yml
@@ -3,7 +3,7 @@ type: theme
 description: Unit theme with Pattern Lab
 base theme: pl_drupal
 version: 3.0.0-beta4
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^10 || ^11
 libraries: {}
 regions:
   #header: Header

--- a/subthemes/pl_unit/pl_unit.libraries.yml
+++ b/subthemes/pl_unit/pl_unit.libraries.yml
@@ -1,24 +1,5 @@
+# Preserve the legacy subtheme library handle while using base theme assets.
 core:
   version: 1.x
-  css:
-    theme:
-      /core/themes/seven/css/components/tabs.css:
-         preprocess: false
-      bower_components/motion-ui/dist/motion-ui.min.css:
-        preprocess: true
-      dest/style.css:
-        preprocess: false
-  js:
-    dest/script.js:
-      preprocess: true
-    bower_components/foundation-sites/dist/js/foundation.min.js:
-      preprocess: true
-    js/app.js:
-      preprocess: true
-
-  # see all in Drupal's `core/core.libraries.yml`
   dependencies:
-    - core/jquery
-    - core/drupal
-    - core/jquery.cookie
-    - core/jquery.once
+    - pl_drupal/core


### PR DESCRIPTION
Changes:

- obvious `^11` in info files and removed `^9` support
- `css` and `js` keys removed in sub theme info files that pointed to assets that appear to never have been used in Drupal 10
- inherit `pl_drupal/core` dependencies from parent theme
- pass a render array to Twig instead of calling `render()`
  - see https://www.drupal.org/docs/theming-drupal/twig-in-drupal/twig-best-practices-preprocess-functions-and-templates#render 
- same `file_create_url()` update as was needed in the profile/upstream